### PR TITLE
feat(validation): allow -1 to bypass and support zero as a valid score

### DIFF
--- a/drf_recaptcha/fields.py
+++ b/drf_recaptcha/fields.py
@@ -79,9 +79,16 @@ class ReCaptchaV3Field(CharField):
 
         self.required_score = (
             action_score_from_settings
-            or required_score
-            or default_score_from_settings
-            or DEFAULT_V3_SCORE
+            if action_score_from_settings is not None
+            else (
+                required_score
+                if required_score is not None
+                else (
+                    default_score_from_settings
+                    if default_score_from_settings is not None
+                    else DEFAULT_V3_SCORE
+                )
+            )
         )
 
         secret_key = secret_key or settings.DRF_RECAPTCHA_SECRET_KEY

--- a/drf_recaptcha/validators.py
+++ b/drf_recaptcha/validators.py
@@ -131,7 +131,7 @@ class ReCaptchaV3Validator(ReCaptchaValidator):
 
         action = check_captcha_response.extra_data.get("action", "")
 
-        if self.recaptcha_required_score >= float(self.score):
+        if self.recaptcha_required_score > float(self.score):
             logger.error(
                 "ReCAPTCHA validation failed due to score of %s"
                 " being lower than the required amount for action '%s'.",

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,5 +1,6 @@
 import pytest
 from django.core.exceptions import ImproperlyConfigured
+from drf_recaptcha import constants
 
 from drf_recaptcha.fields import ReCaptchaV2Field, ReCaptchaV3Field
 from drf_recaptcha.validators import ReCaptchaV2Validator, ReCaptchaV3Validator
@@ -118,3 +119,22 @@ def test_recaptcha_v3_field_score_improperly_configured(
         ReCaptchaV3Field(action="test_action", **params)
 
     assert str(exc_info.value) == error
+
+
+@pytest.mark.parametrize(
+    ("params", "from_settings", "settings_default", "expected"),
+    [
+        ({"required_score": 0}, {}, None, 0),  # Expect 0 because it's explicitly set
+    ],
+)
+def test_recaptcha_v3_field_valid_scores(
+    params, from_settings, settings_default, expected, settings, monkeypatch
+):
+    # Mock settings
+    monkeypatch.setattr(constants, "DEFAULT_V3_SCORE", None)
+
+    settings.DRF_RECAPTCHA_ACTION_V3_SCORES = from_settings
+    settings.DRF_RECAPTCHA_DEFAULT_V3_SCORE = settings_default
+
+    field = ReCaptchaV3Field(action="test_action", **params)
+    assert field.required_score == expected

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -20,6 +20,13 @@ def _drf_recaptcha_testing(settings):
                 is_valid=True, extra_data={"score": 0.6, "action": "test_action"}
             ),
         ),
+        (
+            ReCaptchaV3Validator,
+            {"action": "test_action", "required_score": 0.5},
+            RecaptchaResponse(
+                is_valid=True, extra_data={"score": 0.5, "action": "test_action"}
+            ),
+        ),
     ]
 )
 def validator_with_mocked_captcha_valid_response(request, mocker):


### PR DESCRIPTION
- allow -1 required_score value to bypass check
- support for 0 required_score value